### PR TITLE
Remove `undefined` from `Optional` type

### DIFF
--- a/src/core-api/common/Optional.ts
+++ b/src/core-api/common/Optional.ts
@@ -1,1 +1,1 @@
-export type Optional<T> = T | null | undefined;
+export type Optional<T> = T | null;


### PR DESCRIPTION
Fields on types returned by Core API will never be undefined, therefore, `Optional<T>` is defined as `T | null`.